### PR TITLE
Reply with error on unknown event instead of crashing the process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-await-websockets",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "A async/await solution to websockets",
   "main": "server.js",
   "types": "index.d.ts",

--- a/server.js
+++ b/server.js
@@ -71,7 +71,14 @@ export default async (
         const [event, body] = JSON.parse(msg.toString());
         const func = endpoints?.[event];
 
-        const resolution = func && func(body || {}, { ws, ...services });
+        if (!func) {
+          const error = `Unknown event: ${event}`;
+          console.error(error, "— registered:", Object.keys(endpoints));
+          ws.send(JSON.stringify([event, { error }]));
+          return;
+        }
+
+        const resolution = func(body || {}, { ws, ...services });
 
         (async () => {
           try {


### PR DESCRIPTION
## Summary
- An unknown event from a client falls through to `func.constructor.name === "AsyncFunction"` on `undefined` at `server.js:83`, throwing inside an unguarded async IIFE. Bun turns the unhandled rejection into a process crash — one stray event name takes down every connected client.
- Guard the lookup: when the event isn't registered, log it (with the registered keys, for diagnosis), send `{ error: "Unknown event: <name>" }` back to the caller, and return. The good path is unchanged.
- This is the same bug across all of 3.0.3 → 3.0.6 (byte-identical in the relevant block), so bumping doesn't help; this is the actual fix. Version bumped to 3.0.7.

## Test plan
- [ ] Start an example server with no `events/foo/bar.js` endpoint
- [ ] From a client, `ws.send(JSON.stringify(['foo/bar', {}]))` — server logs `Unknown event: foo/bar — registered: [...]` and the process stays up; client receives `["foo/bar", { error: "Unknown event: foo/bar" }]`
- [ ] Known events still work end-to-end (async + sync handlers, broadcast unaffected)