### PR TITLE
Scope package as @ape-egg/async-await-websockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
-  "name": "async-await-websockets",
+  "name": "@ape-egg/async-await-websockets",
   "version": "3.0.7",
   "description": "A async/await solution to websockets",
   "main": "server.js",
   "types": "index.d.ts",
   "module": "client.js",
   "type": "module",
+  "files": [
+    "server.js",
+    "client.js",
+    "index.d.ts",
+    "README.md"
+  ],
   "author": "Kkortes",
-  "license": "ISC"
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  }
 }


### PR DESCRIPTION
## Summary
- Rename to `@ape-egg/async-await-websockets` to land it under the same npm scope as the other ape-egg packages (vibe, prettier-plugin-vibe, vite-plugin-vibe).
- Add `publishConfig.access: "public"` (required to publish a scoped package as public) and a `files` allowlist so the npm tarball only ships the runtime files.

## Test plan
- [ ] `npm publish --dry-run` lists exactly: `server.js`, `client.js`, `index.d.ts`, `README.md`, `package.json`
- [ ] Consumer side (webdev-game-stack PR) installs and runs against the new scoped name