### PR TITLE
feat: add rooms for targeted multicast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project are documented here. This project adheres to [Semantic Versioning](https://semver.org/).
+
+## [3.1.0]
+
+### Added
+
+- **Rooms** — a `room` API exposed in every event handler's context for targeted multicast to named subsets of connections. Membership is per-connection and clears automatically on disconnect.
+  - `room.join(name)` / `room.leave(name)` — manage membership.
+  - `room.emit(name, event, data, except?)` — multicast to a room, optionally excluding one connection; returns the number of clients sent to.
+  - `room.size(name)` — current member count.
+
+## [3.0.7]
+
+### Changed
+
+- Scoped the package as `@ape-egg/async-await-websockets`.
+
+## [3.0.0]
+
+### Changed
+
+- Now running on [Bun](https://bun.sh/) instead of Node.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Async-await-websockets is now running on Bun (https://bun.sh/). Until the most p
 - ✅ Enables `async/await` messaging from the client
 - ✅ Broadcast messages
 - ✅ Automatic reconnection
-- ❌ Procedural chat rooms
+- ✅ Rooms — targeted multicast to named subsets of connections
 - ❌ Client authentication
 
 ## How to create your own server
@@ -56,9 +56,9 @@ Default: `events`
 
 ### services (object)
 
-Third party services that you need access to in your socket events (e.g. database connection). `ws` is always exposed and cannot be removed.
+Third party services that you need access to in your socket events (e.g. database connection). `ws` and `room` are always exposed and cannot be removed.
 
-Default: `{ ws: [Websocket Object] }`
+Default: `{ ws: [Websocket Object], room: [Room API] }`
 
 ### port (integer)
 
@@ -89,6 +89,26 @@ export default async (body, services) => {
 ```
 
 Omitting the `async` keyword will treat the event as a regular websocket event.
+
+## Rooms
+
+Every event handler receives a `room` API alongside `ws`. Rooms are named subsets of connections you can multicast to — useful for chat channels, game lobbies, or any group of clients that should receive the same event. Membership is per-connection and clears automatically when a client disconnects.
+
+```
+export default (body, { ws, room }) => {
+  room.join(body.channel);
+  room.emit(body.channel, 'joined', { id: ws.data }, ws);
+};
+```
+
+### `room` API
+
+- `room.join(name)` — add the current connection to room `name` (created on demand).
+- `room.leave(name)` — remove the current connection from room `name` (room is deleted when empty).
+- `room.emit(name, event, data, except?)` — send `[event, data]` to every member of `name`, optionally skipping one connection (e.g. pass `ws` to exclude the sender). Returns the number of clients sent to.
+- `room.size(name)` — number of connections currently in room `name`.
+
+`emit` is connection-agnostic, so a later callback (e.g. a timer) can multicast to a room after the triggering message has resolved.
 
 ## Your client
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ape-egg/async-await-websockets",
-  "version": "3.0.7",
+  "version": "3.1.0",
   "description": "A async/await solution to websockets",
   "main": "server.js",
   "types": "index.d.ts",
@@ -10,7 +10,8 @@
     "server.js",
     "client.js",
     "index.d.ts",
-    "README.md"
+    "README.md",
+    "CHANGELOG.md"
   ],
   "author": "Kkortes",
   "license": "ISC",

--- a/server.js
+++ b/server.js
@@ -53,6 +53,37 @@ export default async (
         ws !== client && client.send(JSON.stringify(["broadcast", body])),
     );
 
+  // Rooms: targeted multicast to a named subset of connections. Membership is
+  // per-connection (a Set of ws), so it clears automatically on disconnect.
+  // Handlers receive a `room` API in their context; emit is ws-agnostic so a
+  // later callback (e.g. a timer) can multicast after the triggering message.
+  const rooms = {};
+
+  const joinRoom = (ws, name) => (rooms[name] ??= new Set()).add(ws);
+
+  const leaveRoom = (ws, name) => {
+    const members = rooms[name];
+    if (!members) return;
+    members.delete(ws);
+    if (!members.size) delete rooms[name];
+  };
+
+  const leaveAllRooms = (ws) => {
+    for (const name of Object.keys(rooms)) leaveRoom(ws, name);
+  };
+
+  const emitToRoom = (name, event, data, except = undefined) => {
+    const members = rooms[name];
+    if (!members) return 0;
+    let sent = 0;
+    for (const client of members)
+      if (client !== except) {
+        client.send(JSON.stringify([event, data]));
+        sent += 1;
+      }
+    return sent;
+  };
+
   serve({
     port,
     fetch: (req, server) => {
@@ -78,7 +109,14 @@ export default async (
           return;
         }
 
-        const resolution = func(body || {}, { ws, ...services });
+        const room = {
+          join: (name) => joinRoom(ws, name),
+          leave: (name) => leaveRoom(ws, name),
+          emit: emitToRoom,
+          size: (name) => rooms[name]?.size || 0,
+        };
+
+        const resolution = func(body || {}, { ws, room, ...services });
 
         (async () => {
           try {
@@ -120,6 +158,7 @@ export default async (
       },
       close: (ws, code, message) => {
         delete clientPool[ws.data];
+        leaveAllRooms(ws);
       },
       drain: (ws) => {},
     },


### PR DESCRIPTION
## What

Adds a **Rooms** API for targeted multicast to named subsets of connections — useful for chat channels, game lobbies, or any group of clients that should receive the same event.

Every event handler now receives a `room` object alongside `ws`:

- `room.join(name)` / `room.leave(name)` — manage membership (rooms are created on demand and deleted when empty)
- `room.emit(name, event, data, except?)` — multicast `[event, data]` to a room, optionally excluding one connection (e.g. the sender); returns the number of clients sent to
- `room.size(name)` — current member count

Membership is per-connection (a `Set` of `ws`), so it clears automatically on disconnect via `leaveAllRooms`. `emit` is connection-agnostic, so a later callback (e.g. a timer) can multicast after the triggering message resolves.

## Changes

- `server.js` — room registry + `room` API wired into handler context and disconnect cleanup
- Version bump `3.0.7` → `3.1.0` (backward-compatible feature)
- `README.md` — Rooms section, `room` documented in services context, feature list updated
- `CHANGELOG.md` — added

🤖 Generated with [Claude Code](https://claude.com/claude-code)