### PR TITLE
chore: add simple release scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ In both cases `sendAsync` will throw an object that contains an error-message li
 
 ## Publishing
 
-- `bun release:check` — dry-run `npm pack` to preview the published tarball.
-- `bun release` — runs the check, prompts for a new version (or keeps the current one), and publishes `@ape-egg/async-await-websockets` to npm.
+- `bun run publish:check` — dry-run `npm pack` to preview the published tarball.
+- `bun run publish` — runs the check, prompts for a new version (or keeps the current one), and publishes `@ape-egg/async-await-websockets` to npm.
 
-Requires being logged in to npm (`npm login`).
+Use `bun run publish` (not `bun publish`, which is Bun's own built-in publisher and skips the script). Requires being logged in to npm (`npm login`).

--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ In both cases `sendAsync` will throw an object that contains an error-message li
   error: "What went wrong"
 }
 ```
+
+## Publishing
+
+- `bun release:check` — dry-run `npm pack` to preview the published tarball.
+- `bun release` — runs the check, prompts for a new version (or keeps the current one), and publishes `@ape-egg/async-await-websockets` to npm.
+
+Requires being logged in to npm (`npm login`).

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "module": "client.js",
   "type": "module",
   "scripts": {
-    "release:check": "npm pack --dry-run",
-    "release": "bun release:check && ./scripts/publish.sh"
+    "publish:check": "npm pack --dry-run",
+    "publish": "bun publish:check && ./scripts/publish.sh"
   },
   "files": [
     "server.js",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "types": "index.d.ts",
   "module": "client.js",
   "type": "module",
+  "scripts": {
+    "release:check": "npm pack --dry-run",
+    "release": "bun release:check && ./scripts/publish.sh"
+  },
   "files": [
     "server.js",
     "client.js",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Publish @ape-egg/async-await-websockets to npm
+
+set -e
+
+echo "Publishing @ape-egg/async-await-websockets..."
+echo ""
+
+# Check if logged in to npm
+if ! npm whoami &> /dev/null; then
+  echo "Error: Not logged in to npm. Run 'npm login' first."
+  exit 1
+fi
+
+# Show current version
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+echo "Current version: $CURRENT_VERSION"
+echo ""
+
+# Ask for new version
+read -p "New version (or press enter to keep $CURRENT_VERSION): " NEW_VERSION
+
+if [ -n "$NEW_VERSION" ]; then
+  npm version "$NEW_VERSION" --no-git-tag-version
+  echo "Updated to version $NEW_VERSION"
+fi
+
+# Publish
+echo ""
+echo "Publishing..."
+npm publish --access public
+
+echo ""
+echo "Done! Published @ape-egg/async-await-websockets"


### PR DESCRIPTION
## What

Adds a simple, interactive release flow for publishing `@ape-egg/async-await-websockets` to npm — mirroring the approach used in the vibe project.

The package is already scoped (`@ape-egg/async-await-websockets`) with `publishConfig.access: public` and is live on npm; this PR just adds the tooling to cut releases.

## Changes

- `scripts/publish.sh` — checks npm login, shows the current version, prompts for a new one (`npm version --no-git-tag-version`), then `npm publish --access public`.
- `package.json` scripts:
  - `release:check` — `npm pack --dry-run` to preview the tarball
  - `release` — runs the check, then the publish script
- `README.md` — a short **Publishing** section documenting the flow.

## Usage

```
bun release:check   # preview what gets published
bun release         # bump version + publish (requires npm login)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)