### PR TITLE
fix: apply the reconnectInterval default when options is passed

### DIFF
--- a/client.js
+++ b/client.js
@@ -11,7 +11,7 @@ const AsyncAwaitWebsocket = (url, options) => {
   // Create once; reuse across internal reconnects so listeners registered via
   // ws.on survive.
   eventTarget = eventTarget || new EventTarget();
-  const { reconnectInterval } = options || { reconnectInterval: 1000 };
+  const { reconnectInterval = 1000 } = options || {};
 
   ws = new WebSocket(url, generateID());
   ws.sid = ws.protocol;


### PR DESCRIPTION
## Problem

`client.js:14` applied the 1000ms reconnect default only when `options` was entirely falsy:

```js
const { reconnectInterval } = options || { reconnectInterval: 1000 };
```

Pass *any* options object — `{}`, `{ debug: true }`, anything without an explicit `reconnectInterval` — and the fallback object is never used, so `reconnectInterval` destructures to `undefined`. The close handler then runs `setTimeout(reconnect, undefined)`, which fires at 0ms: a tight reconnect loop against an unreachable server.

Repro against a dead port, counting `WebSocket` constructions over 300ms:

| `options` | before | after |
| --- | --- | --- |
| `{}` | **249** | 1 |
| `{ reconnectInterval: 50 }` | 6 | 6 |
| omitted | 1 | 1 |

## Fix

One line — move the default into the destructuring, where it applies per-property instead of per-object:

```js
const { reconnectInterval = 1000 } = options || {};
```

## Verification

Instrumented `globalThis.WebSocket` to count constructions, pointed the client at a closed port, and sampled for 300ms on both the old and new file (numbers in the table above). `{}` drops from hundreds of sockets to a single one, an explicit `reconnectInterval: 50` still reconnects on its 50ms cadence, and omitting `options` is unchanged.

## Note

Touches the same line region as the parallel `refactor/client-instance` PR, so a trivial conflict is possible. That refactor already carries this fix — if it merges first, this PR can simply be closed.