### PR TITLE
fix: reply based on what the handler returns, not its syntax

### DIFF
--- a/server.js
+++ b/server.js
@@ -117,30 +117,28 @@ export default async (
         };
 
         const resolution = func(body || {}, { ws, room, ...services });
+        // A thenable result means the handler is async and the caller awaits a
+        // reply — regardless of how the handler was declared or wrapped.
+        const isAsync = typeof resolution?.then === "function";
 
         (async () => {
-          try {
-            const res = await resolution;
-          } catch (_) {}
-
-          let result,
-            error,
-            async = func.constructor.name === "AsyncFunction";
+          let result, error;
 
           try {
-            result = async ? await resolution : resolution;
+            result = await resolution;
           } catch (err) {
             error = err.toString();
           }
 
-          async && ws.send(JSON.stringify([event, error ? { error } : result]));
+          isAsync &&
+            ws.send(JSON.stringify([event, error ? { error } : result]));
 
           typeof log === "function" &&
             log(
               {
                 event,
                 websocketKey: ws.data,
-                async,
+                async: isAsync,
                 body: body || {},
                 result,
                 error,


### PR DESCRIPTION
## Repro

Three handlers that should reply, but produce **zero reply frames** on `main`:

```js
// events/plainPromise.js
export default (body) => Promise.resolve({ ok: 1 });

// events/rejecting.js
export default () => Promise.reject(new Error("boom"));

// events/wrapped.js — any wrapper around an async fn (middleware, logger, DI…)
export default ((f) => (...a) => f(...a))(async (body) => ({ wrapped: true }));
```

Client, against `main`:

```
a_plainPromise → rejected { error: "WebSocket error (client): request timed out" }
b_rejecting    → rejected { error: "WebSocket error (client): request timed out" }
c_wrapped      → rejected { error: "WebSocket error (client): request timed out" }
```

Server-side `log()` on `main` for those same three calls:

```
{ event: "plainPromise", async: false, result: {} }   // {} is the raw Promise, JSON-serialized
{ event: "rejecting",    async: false, result: {} }   // the rejection is nowhere
{ event: "wrapped",      async: false, result: {} }
```

The rejection **vanishes entirely** — no reply, no log, no unhandled-rejection warning. The caller's `sendAsync` times out after 3s with a message blaming the network, so the failure looks like a transport problem rather than a handler that never got wired up.

## Root cause

`server.js` decided reply-or-not by sniffing the handler's *syntax*:

```js
async = func.constructor.name === "AsyncFunction";
```

That is true only for a literal `async function`. A handler that returns a promise without the `async` keyword, or an async handler behind any wrapper (the wrapper is a plain arrow), is classified sync — so the `async && ws.send(...)` reply is skipped and `result` is logged as the unawaited Promise object.

The rejections disappeared because of a dead block directly above:

```js
try {
  const res = await resolution;   // res unused; same promise awaited again below
} catch (_) {}                    // swallows the rejection, and marks it handled
```

It awaits `resolution` purely to discard it. Its only effect is marking the promise as handled, so the rejection never surfaces anywhere.

## Fix

Decide from what the handler **returns**, not how it was declared, and drop the dead block:

```js
const resolution = func(body || {}, { ws, room, ...services });
const isAsync = typeof resolution?.then === "function";

(async () => {
  let result, error;

  try {
    result = await resolution;
  } catch (err) {
    error = err.toString();
  }

  isAsync && ws.send(JSON.stringify([event, error ? { error } : result]));
  // …log unchanged, `async: isAsync`
})();
```

One await, one try/catch. A thenable result means "the caller is awaiting a reply"; a plain value keeps today's fire-and-forget behavior for sync handlers. `log()`'s shape is unchanged — the `async` key is still there, just now accurate.

## Semantics — what replies when

| Handler returns | Reply frame | Log `async` | Caller (`sendAsync`) | Changed? |
|---|---|---|---|---|
| `async fn` → value | `[event, result]` | `true` | resolves | no |
| `async fn` → throws | `[event, { error }]` | `true` | rejects | no |
| plain fn → `Promise.resolve(v)` | `[event, v]` | `true` | resolves | **yes** (was: timeout) |
| plain fn → `Promise.reject(e)` | `[event, { error }]` | `true` | rejects with `{ error }` | **yes** (was: timeout, silent) |
| wrapped async fn | `[event, result]` | `true` | resolves | **yes** (was: timeout) |
| plain fn → value | none | `false` | n/a (`sendSync`) | no |
| plain fn → `ws.sendEvent(...)` | only what it sent | `false` | n/a (`sendSync`) | no |

Only the previously-broken rows move. No sync handler starts replying, so nothing that works today changes shape on the wire.

## Verification

Ran the same script against `main` and this branch (server + real client over a live socket, one handler per case):

- **(a)** plain promise-returning handler → caller receives `{ ok: 1, got: {...} }` ✅ (timed out on `main`)
- **(b)** rejecting handler → caller rejects with `{ error: "Error: boom" }` **and** the server logs `{ event: "rejecting", async: true, error: "Error: boom" }` via `console.error` ✅ (on `main`: timeout, and the rejection was logged nowhere)
- **(c)** wrapped async handler → caller receives `{ wrapped: true, got: {...} }` ✅ (timed out on `main`)
- **(d)** true `async` handler, both resolving and throwing → unchanged; resolves with the value / rejects with `{ error: "Error: async boom" }` ✅
- **(e)** plain sync handler returning a value → still **no** reply frame; logged with `async: false` ✅
- **(f)** `sendSync` flow → unchanged; a handler calling `ws.sendEvent("pong", …)` produces exactly that one frame and nothing else ✅

## Note

Trivial expected conflict with the parallel PR `feat/request-correlation`, which touches the same block. Both edits are local to the `message` handler's reply path; whichever lands second should keep the correlation id on the `ws.send(...)` line and this PR's `isAsync` gate around it.
