### PR TITLE
fix: assign sid from the generated id instead of the pre-handshake protocol

### DIFF
--- a/client.js
+++ b/client.js
@@ -13,8 +13,10 @@ const AsyncAwaitWebsocket = (url, options) => {
   eventTarget = eventTarget || new EventTarget();
   const { reconnectInterval } = options || { reconnectInterval: 1000 };
 
-  ws = new WebSocket(url, generateID());
-  ws.sid = ws.protocol;
+  const sid = generateID();
+
+  ws = new WebSocket(url, sid);
+  ws.sid = sid;
 
   ws.sendSync = (event, data) => ws.send(JSON.stringify([event, data]));
 


### PR DESCRIPTION
The client already knows its own id — it generates it. Reading it back off `ws.protocol` never worked.

## The bug

```js
ws = new WebSocket(url, generateID());
ws.sid = ws.protocol;
```

Both lines run synchronously, so the read happens while `readyState` is `CONNECTING`. The negotiated subprotocol is not known until the server responds to the handshake, so `ws.protocol` is the empty string at that moment — in every environment, browsers included. `ws.sid` is therefore **always** `""`.

Two consequences:

- Client code keying anything on `sid` collapses every connection onto a single `""` key.
- The id the server actually uses as its connection id (`ws.data`, taken from the `sec-websocket-protocol` header) is never visible client-side.

Worth noting: `ws.protocol` stays `""` even *after* the handshake here, because the server upgrades without echoing the subprotocol back in its response. So there was no later point at which the old line would have become correct either.

## The fix

Hold the generated id in a variable and assign it directly:

```js
const sid = generateID();

ws = new WebSocket(url, sid);
ws.sid = sid;
```

`sid` is now truthful from construction onward and matches the server's `ws.data` exactly. No dependence on handshake timing, so it behaves identically in browsers and in Bun. `generateID` itself is untouched.

## Verification

Ran the old and new client against a minimal `Bun.serve` echo that upgrades with `data: req.headers.get("sec-websocket-protocol")` and sends `ws.data` back to the client:

```
OLD (ws.sid = ws.protocol): {
  sidAtConstruction: "",
  sidAfterOpen: "",
  serverSaw: "_78895808619913446",
  protocolAfterOpen: "",
}
NEW (fixed client.js):      {
  sidAtConstruction: "_280601524163137601o",
  sidAfterOpen: "_280601524163137601o",
  serverSaw: "_280601524163137601o",
  protocolAfterOpen: "",
}

OLD sid empty:                    true
NEW sid non-empty:                true
NEW sid === server ws.data:       true
NEW sid truthful at construction: true
```

The old client's `sid` is empty while the server holds a real id; the new client's `sid` equals the server's `ws.data`. The throwaway script is not part of this PR.

`index.d.ts` already types `sid: string`, so no type change is needed — the declaration is simply true now.

## Note

Touches the same two lines as the parallel `refactor/client-instance` PR, so expect a trivial conflict depending on merge order.