### PR TITLE
fix: key the broadcast pool by socket identity, not the client-supplied header

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,10 +45,12 @@ export default async (
 
   const endpoints = await serveEndpoints(eventDir, "");
 
-  const clientPool = {};
+  // Keyed by socket identity like rooms — ws.data is a client-supplied header
+  // and collides across connections.
+  const clientPool = new Set();
 
   const broadcast = (body, ws = undefined) =>
-    Object.values(clientPool).forEach(
+    clientPool.forEach(
       (client) =>
         ws !== client && client.send(JSON.stringify(["broadcast", body])),
     );
@@ -150,14 +152,14 @@ export default async (
         })();
       },
       open: (ws) => {
-        clientPool[ws.data] = ws;
+        clientPool.add(ws);
 
         ws.sendEvent = (event, data) => ws.send(JSON.stringify([event, data]));
         ws.broadcast = (body, includeSelf = false) =>
           broadcast(body, includeSelf || ws);
       },
       close: (ws, code, message) => {
-        delete clientPool[ws.data];
+        clientPool.delete(ws);
         leaveAllRooms(ws);
       },
       drain: (ws) => {},


### PR DESCRIPTION
## The failure

`clientPool` was an object keyed by `ws.data` — which is the **client-supplied `sec-websocket-protocol` header**, not an identity the server controls. Three consequences:

- **Collision.** Two vanilla `WebSocket` clients (no subprotocol) both key as `null`. The second connection overwrites the first in the pool, so the first stops receiving `broadcast()` immediately.
- **Eviction of a live socket.** When *either* of those two closes, `delete clientPool[ws.data]` removes the single shared entry. The other socket is still open but is now gone from the pool, and re-adding only happens in `open` — so it never receives another broadcast for the rest of its life.
- **Hijacking.** Any client replaying a victim's header value takes over its pool slot.

Rooms were never affected: they're `Set`s keyed by object identity. That's exactly the shape the pool needed.

## The fix

Replace the object with a `Set` of sockets — `open` adds, `close` deletes, `broadcast` iterates. The pool's only two jobs are "iterate everyone" and "remove on close", neither of which needs a key.

`ws.data` is untouched and still flows to the log as `websocketKey`; it just isn't a map key anymore.

## Verification

Harness: two vanilla `WebSocket` clients (**A**, **B**, no subprotocol) plus one aaw-style client (**C**, with a subprotocol), against a handler calling `ws.broadcast`. Broadcast once with all three connected, close **A**, broadcast again.

| | round 1 (A, B, C connected) | round 2 (after A closed) |
|---|---|---|
| **main** | A ✗  B ✓  C ✓ | A ✗  **B ✗**  C ✓ |
| **this branch** | A ✓  B ✓  C ✓ | A ✗  **B ✓**  C ✓ |

On `main`, A never receives anything (B overwrote its slot), and B goes silent the moment A disconnects — reproducing both symptoms. On this branch every connected client receives every broadcast, and closing A affects only A.

Also confirmed `clientPool` is module-private: the `webdev-game-stack` consumer never reaches into it.

## Note

The parallel PR `refactor/native-pubsub` replaces this pool entirely with Bun's native pub/sub. If that merges first, this PR becomes redundant and can be closed.

No version bump, no CHANGELOG entry — nothing else touched.