### PR TITLE
docs: document sendAsync timeouts for slow calls; name the event in timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ ws.on('open', () => {
 - `payload` (any, default `undefined`)
 - `timeout in ms` (integer, default `3000`)
 
+### Timeouts
+
+The default timeout is `3000` ms, which only fits fast request/response events. Anything slower — image generation, LLM calls, report builds, large uploads — needs an explicit timeout:
+
+```
+const image = await ws.sendAsync('imagegen/generate', { prompt }, 30_000);
+```
+
+When the timeout fires, `sendAsync` removes its reply listener and rejects with `{ error: "WebSocket error (client): request timed out: imagegen/generate" }`. The server is not cancelled — it keeps running the handler, and its reply arrives to no listener and is dropped. For a handler that costs money or writes to a database, the work still happened; you just never see the result.
+
+Size the timeout from the slowest expected handler, not the average one.
+
 ## Error handling
 
 When calling `ws.sendAsync('some-event')` there are two possible failures:

--- a/client.js
+++ b/client.js
@@ -28,7 +28,9 @@ const AsyncAwaitWebsocket = (url, options) => {
 
       const id = setTimeout(() => {
         eventTarget.removeEventListener(event, trigger);
-        reject({ error: "WebSocket error (client): request timed out" });
+        reject({
+          error: `WebSocket error (client): request timed out: ${event}`,
+        });
       }, timeout);
 
       ws.send(JSON.stringify([event, data]));


### PR DESCRIPTION
## Problem

`sendAsync(event, data, timeout = 3000)` defaults to a 3 second timeout. That fits fast request/response events, but consumer projects call it against slow backends without passing a timeout — e.g. `await api.sendAsync('imagegen/generate', { prompt })` against a 5-20s image-generation service.

What happens then: at 3s the client removes its reply listener and rejects. The server is never cancelled — it finishes the generation, gets billed for it, and sends the reply to zero listeners, where it is silently dropped. The caller sees a timeout, the work happened anyway, and the result vanishes.

The README documented the default value but never warned that slow RPCs need an explicit timeout, and gave no example. On top of that, every timeout produced the identical message `"WebSocket error (client): request timed out"`, so a timeout in a client with many concurrent calls gave no hint which call failed.

## What changed

**README.md** — new `Timeouts` section under `ws.sendAsync` parameters:
- worked example of a long-running call: `ws.sendAsync('imagegen/generate', { prompt }, 30_000)`
- plain statement of timeout behavior: rejects, drops the late reply, server still did (and billed) the work
- recommendation: size the timeout from the slowest expected handler, not the average one

**client.js** — the timeout rejection now names the event: `request timed out: ${event}`. Behavior is otherwise unchanged; only the message string differs, so a timeout points at the offending call.

No version bump, no CHANGELOG, nothing else touched.

## Verification

Throwaway Bun script (not committed): real `server.js` with a handler that sleeps 5s, real `client.js`.

- **(a) default timeout** → rejected with `WebSocket error (client): request timed out: slow/thing` — the event name is in the message.
- **(b) explicit 15000ms timeout** → resolved normally with the handler's payload.
