### PR TITLE
fix: guard the message path so client input cannot kill the process

### DIFF
--- a/server.js
+++ b/server.js
@@ -99,7 +99,21 @@ export default async (
     },
     websocket: {
       message: (ws, msg) => {
-        const [event, body] = JSON.parse(msg.toString());
+        let event, body;
+
+        // The trust boundary: everything past this point is client input
+        try {
+          const frame = JSON.parse(msg.toString());
+          if (!Array.isArray(frame))
+            throw new Error("expected an [event, data] tuple");
+          [event, body] = frame;
+        } catch (err) {
+          const error = `Malformed message: ${err.message}`;
+          console.error(error, "— received:", msg.toString());
+          ws.send(JSON.stringify(["error", { error }]));
+          return;
+        }
+
         const func = endpoints?.[event];
 
         if (!func) {
@@ -116,24 +130,19 @@ export default async (
           size: (name) => rooms[name]?.size || 0,
         };
 
-        const resolution = func(body || {}, { ws, room, ...services });
-
         (async () => {
-          try {
-            const res = await resolution;
-          } catch (_) {}
-
           let result,
             error,
             async = func.constructor.name === "AsyncFunction";
 
           try {
-            result = async ? await resolution : resolution;
+            result = await func(body || {}, { ws, room, ...services });
           } catch (err) {
             error = err.toString();
           }
 
-          async && ws.send(JSON.stringify([event, error ? { error } : result]));
+          (async || error) &&
+            ws.send(JSON.stringify([event, error ? { error } : result]));
 
           typeof log === "function" &&
             log(


### PR DESCRIPTION
## The crash

The `message` handler parsed, destructured and invoked the handler with no guard at all. Any of those three steps can throw, and a throw out of Bun's `websocket.message` callback is fatal: the **entire server process dies with exit 1** and every connected client drops with 1006. One malicious or merely buggy client takes down every other client.

Reproduced against `main` (fresh server per case, raw frames from a bare `WebSocket`):

| frame sent | result on `main` |
| --- | --- |
| `hello` | **DEAD exit=1** — `SyntaxError: JSON Parse error: Unexpected identifier "hello"`, client 1006 |
| `null` | **DEAD exit=1** — `TypeError: null is not an object` |
| `{"event":"echo"}` | **DEAD exit=1** — `TypeError: undefined is not a function (near '...[event, body]...')` |
| `["boom-sync",{}]` (non-async handler that throws) | **DEAD exit=1** — the throw escapes `func(...)` |
| `["boom-async",{}]` (async handler that rejects) | ALIVE — error reply, already correct |

This is the same crash class as the 3.0.7 "reply with an error on unknown event instead of crashing" fix, one line lower: the unknown-event branch was hardened, the parse and invoke around it were not.

## The fix

One honest guard at the trust boundary, plus one at the handler call — no scattered checks.

**Frame decoding.** `JSON.parse`, the array check and the destructure sit in a single `try`, so unparseable bytes, `null`, and non-array frames all land in the same `catch`. There is no event name to reply on for an undecodable frame, so the reply goes out as `["error", { error }]` and is also logged server-side. Replying beats closing with a policy code: it keeps the existing "tell the caller what went wrong, keep everyone else running" contract of the unknown-event branch, it costs the other connections nothing (the bad frame is per-connection anyway), and a hand-rolled client gets a diagnosable message instead of a silent hang. `["error", …]` never collides with a real reply — `sendAsync` only listens for the event name it sent, and this library's own client can't produce an undecodable frame.

**Handler invocation.** The call moved inside the existing `try` and is now `await`ed, so a synchronously-throwing handler behaves exactly like an async handler that rejects: caught, replied as `{ error }`, logged. The send condition became `(async || error)` — successful sync handlers stay fire-and-forget as documented, but an error always reaches the caller, since silently swallowing it is what the old code only ever avoided by crashing.

This also removes the `try { const res = await resolution } catch (_) {}` block above it. It existed to swallow rejections from non-async handlers that return a promise (otherwise an unhandled rejection would take the process down too). Awaiting the call inside the real `try` covers that case properly: the rejection is now caught, reported to the caller and logged instead of discarded.

No version bump, no CHANGELOG edit, nothing else touched.

## Verification

Throwaway Bun scripts, real server process, raw frames — all eight cases against one long-lived server:

| case | frame | result |
| --- | --- | --- |
| a | `hello` | ALIVE — `["error",{"error":"Malformed message: JSON Parse error: Unexpected identifier \"hello\""}]` + `console.error` |
| b | `null` | ALIVE — `["error",{"error":"Malformed message: expected an [event, data] tuple"}]` |
| c | `{"event":"echo"}` | ALIVE — same tuple error |
| d | `["boom-sync",{}]` | ALIVE — `["boom-sync",{"error":"Error: sync handler exploded"}]` |
| e | `["boom-async",{}]` | ALIVE — `["boom-async",{"error":"Error: async handler exploded"}]` (unchanged) |
| f | `["nope",{}]` | ALIVE — `["nope",{"error":"Unknown event: nope"}]` (unchanged) |
| g | `["ping",{}]` | ALIVE — `["pong",{"ok":true}]`, no spurious reply frame |
| h | `["echo",{"value":42}]` | ALIVE — `["echo",{"echoed":42}]` |

The process survived every case and the socket stayed open throughout; on `main` cases a–d each killed it outright.

End-to-end through the real `client.js`:

```
echo       -> resolved { echoed: 7 }
boom-sync  -> rejected { error: "Error: sync handler exploded" }
boom-async -> rejected { error: "Error: async handler exploded" }
echo       -> resolved { echoed: 8 }
process alive: true | socket open: true
```

`sendAsync` against a throwing sync handler now rejects with the documented `{ error }` shape, and the connection keeps serving afterwards.
