### PR TITLE
refactor: per-instance client with dispose and correct off

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,11 +131,33 @@ ws.on('open', () => {
 });
 ```
 
-### `ws.sendAsync` parameters:
+Every `aaw(url, options)` call returns its own independent client — socket, event bus and reconnect timer live on that instance, so two clients in the same app never see each other's traffic.
 
-- `event name` (string, required)
-- `payload` (any, default `undefined`)
-- `timeout in ms` (integer, default `3000`)
+### `aaw(url, options)`
+
+- `url` (string, required)
+- `options.reconnectInterval` (integer, default `1000`) — delay before reconnecting after a drop.
+
+### Client API
+
+- `ws.sendAsync(event, payload, timeout)` — send and await the server's reply.
+  - `event name` (string, required)
+  - `payload` (any, default `undefined`)
+  - `timeout in ms` (integer, default `3000`)
+- `ws.sendSync(event, payload)` — fire and forget.
+- `ws.on(event, callback)` — listen for an event; returns an unsubscribe function.
+- `ws.off(event, callback)` — remove that exact registration, leaving other listeners for the same event attached.
+- `ws.sid` — the current socket id.
+- `ws.dispose()` — stop reconnecting and close the socket. This is the only supported shutdown; closing the underlying socket by other means just triggers a reconnect.
+
+```
+const unsubscribe = ws.on('notify', (data) => console.info(data));
+
+unsubscribe();       // or: ws.off('notify', callback)
+ws.dispose();        // done with this client
+```
+
+The returned client survives reconnects: it rebinds its internal socket, so a handle you stored (and the listeners registered on it) keeps working after the connection drops and comes back.
 
 ## Error handling
 

--- a/client.js
+++ b/client.js
@@ -1,5 +1,3 @@
-let ws, reconnector, eventTarget;
-
 const generateID = () =>
   `_${
     Number(String(Math.random()).slice(2)) +
@@ -8,17 +6,39 @@ const generateID = () =>
   }`;
 
 const AsyncAwaitWebsocket = (url, options) => {
-  // Create once; reuse across internal reconnects so listeners registered via
-  // ws.on survive.
-  eventTarget = eventTarget || new EventTarget();
-  const { reconnectInterval } = options || { reconnectInterval: 1000 };
+  const { reconnectInterval = 1000 } = options || {};
+  // One bus per instance; it outlives the sockets so listeners registered via
+  // `on` survive internal reconnects.
+  const eventTarget = new EventTarget();
+  const listeners = new Map();
+  let socket, reconnector, disposed;
 
-  ws = new WebSocket(url, generateID());
-  ws.sid = ws.protocol;
+  const connect = () => {
+    socket = new WebSocket(url, generateID());
 
-  ws.sendSync = (event, data) => ws.send(JSON.stringify([event, data]));
+    socket.addEventListener("open", (detail) => {
+      clearTimeout(reconnector);
+      eventTarget.dispatchEvent(new CustomEvent("open", { detail }));
+    });
 
-  ws.sendAsync = (event, data, timeout = 3000) =>
+    socket.addEventListener("close", (detail) => {
+      disposed || (reconnector = setTimeout(connect, reconnectInterval));
+      eventTarget.dispatchEvent(new CustomEvent("close", { detail }));
+    });
+
+    socket.addEventListener("error", (detail) =>
+      eventTarget.dispatchEvent(new CustomEvent("error", { detail })),
+    );
+
+    socket.addEventListener("message", ({ data }) => {
+      const [event, detail] = JSON.parse(data);
+      eventTarget.dispatchEvent(new CustomEvent(event, { detail }));
+    });
+  };
+
+  const sendSync = (event, data) => socket.send(JSON.stringify([event, data]));
+
+  const sendAsync = (event, data, timeout = 3000) =>
     new Promise((resolve, reject) => {
       const trigger = ({ detail }) => {
         clearTimeout(id);
@@ -31,39 +51,42 @@ const AsyncAwaitWebsocket = (url, options) => {
         reject({ error: "WebSocket error (client): request timed out" });
       }, timeout);
 
-      ws.send(JSON.stringify([event, data]));
+      socket.send(JSON.stringify([event, data]));
       eventTarget.addEventListener(event, trigger);
     });
 
-  ws.on = (event, callback) => {
-    const cb = ({ detail }) => callback(detail);
-    eventTarget.addEventListener(event, cb);
-    ws.off = (event) => eventTarget.removeEventListener(event, cb);
+  const off = (event, callback) => {
+    const registered = listeners.get(event);
+    eventTarget.removeEventListener(event, registered?.get(callback));
+    registered?.delete(callback);
   };
 
-  ws.addEventListener("open", (detail) => {
+  const on = (event, callback) => {
+    const wrapped = ({ detail }) => callback(detail);
+    const registered = listeners.get(event) || new Map();
+    listeners.set(event, registered.set(callback, wrapped));
+    eventTarget.addEventListener(event, wrapped);
+    return () => off(event, callback);
+  };
+
+  const dispose = () => {
+    disposed = true;
     clearTimeout(reconnector);
-    eventTarget.dispatchEvent(new CustomEvent("open", { detail }));
-  });
+    socket.close();
+  };
 
-  ws.addEventListener("close", (detail) => {
-    reconnector = setTimeout(
-      AsyncAwaitWebsocket.bind(undefined, url, options),
-      reconnectInterval,
-    );
-    eventTarget.dispatchEvent(new CustomEvent("close", { detail }));
-  });
+  connect();
 
-  ws.addEventListener("error", (detail) =>
-    eventTarget.dispatchEvent(new CustomEvent("error", { detail })),
-  );
-
-  ws.addEventListener("message", ({ data }) => {
-    const [event, detail] = JSON.parse(data);
-    eventTarget.dispatchEvent(new CustomEvent(event, { detail }));
-  });
-
-  return ws;
+  return {
+    get sid() {
+      return socket.protocol;
+    },
+    sendSync,
+    sendAsync,
+    on,
+    off,
+    dispose,
+  };
 };
 
 export default AsyncAwaitWebsocket;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,8 @@
-export type AsyncAwaitWebsocket = WebSocket & {
-  sid: string;
+export type AsyncAwaitWebsocket = {
+  readonly sid: string;
   sendSync: (event: string, data: any) => void;
-  sendAsync: (event: string, data: any, timeout?: number) => any;
+  sendAsync: (event: string, data: any, timeout?: number) => Promise<any>;
+  on: (event: string, callback: (data: any) => void) => () => void;
+  off: (event: string, callback: (data: any) => void) => void;
+  dispose: () => void;
 };


### PR DESCRIPTION
The client kept its socket, event bus and reconnect timer in module-level variables (`let ws, reconnector, eventTarget;`) and reconnected by re-running the factory. That single piece of shared state caused four confirmed defects.

## Confirmed defects

1. **No supported shutdown.** A caller-initiated `ws.close()` fired the `close` listener, which scheduled another connect — so closing the socket reconnected it, forever. There was no way to stop a client.
2. **Instances trampled each other.** A second `AsyncAwaitWebsocket(urlB)` call overwrote the module `ws`/`eventTarget`, so B's traffic resolved A's pending `sendAsync` calls and fired A's handlers.
3. **`off` removed the wrong thing.** `ws.off` was reassigned by every `ws.on` call and closed over only the newest wrapper. `on('a', f); on('b', g); off('a')` removed nothing, and `f` stayed attached.
4. **Listeners accumulated across reconnects**, with no dedupe, because the shared bus was reused by every replacement socket.

## Design

`AsyncAwaitWebsocket(url, options)` is now a factory closure — no module-level state at all. Each call owns its socket ref, `EventTarget`, reconnect timer and listener registry; plain functions only, no classes.

- `connect()` rebinds the **internal** socket ref, and `sendSync`/`sendAsync` close over that ref — so a stored handle (and everything registered on it) keeps working across reconnects, exactly as before, minus the global.
- `dispose()` sets the disposed flag, clears the pending reconnect timer and closes the socket — the deliberate shutdown that was missing.
- `on(event, callback)` keeps a per-instance `Map` of `event → callback → wrapper` and returns an unsubscribe function; `off(event, callback)` removes exactly that registration and leaves other listeners for the same event attached.
- Since the line was being touched anyway, the options default is now the correct destructuring default `{ reconnectInterval = 1000 } = options || {}` (the old `options || { reconnectInterval: 1000 }` left `reconnectInterval` undefined whenever any options object was passed).

Public surface is preserved: `sendSync`, `sendAsync(event, data, timeout = 3000)`, `on`, `off`, `sid`, auto-reconnect. The returned value is now a plain handle object rather than the raw `WebSocket` — `sid` is a live getter over the current socket, and shutdown goes through `dispose()` instead of `close()`. `index.d.ts` and the README client section are updated (client API, unsubscribe, `dispose`).

## Verification

Empirically checked against a throwaway Bun ws echo server (scripts not committed), counting `WebSocket` constructions:

- round-trip `sendAsync` works;
- server killed and restarted → the **same held handle** reconnects and `sendAsync` works again (socket reconstructed, handlers survived);
- `dispose()` → zero further constructions after the server dies (verified on both a freshly opened and a long-lived, already-reconnected instance);
- two instances against two servers → no cross-delivery, on either `sendAsync` replies or `on` handlers, and instance A is unaffected by B's lifecycle;
- `off(event, callback)` removes exactly the named registration, others intact; the returned unsubscribe function behaves the same; `off` with an unregistered callback or unknown event is a no-op.

## Note on parallel PRs

`fix/reconnect-interval-default` and `fix/client-sid` touch the same file — expect small conflicts. This PR **subsumes** the reconnect-interval fix. It does not change `sid` semantics (still the current socket's `protocol`, just a live per-instance getter), so the `sid` fix still applies on top.
