### PR TITLE
refactor: back rooms and broadcast with Bun's native pub/sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Omitting the `async` keyword will treat the event as a regular websocket event.
 
 Every event handler receives a `room` API alongside `ws`. Rooms are named subsets of connections you can multicast to — useful for chat channels, game lobbies, or any group of clients that should receive the same event. Membership is per-connection and clears automatically when a client disconnects.
 
+Rooms and broadcasts are backed by [Bun's native pub/sub](https://bun.sh/docs/api/websockets#pub-sub), so each message is serialized once and fanned out by the runtime. Room names are namespaced as the topic `room:<name>` and cannot collide with the global broadcast topic.
+
 ```
 export default (body, { ws, room }) => {
   room.join(body.channel);
@@ -105,7 +107,7 @@ export default (body, { ws, room }) => {
 
 - `room.join(name)` — add the current connection to room `name` (created on demand).
 - `room.leave(name)` — remove the current connection from room `name` (room is deleted when empty).
-- `room.emit(name, event, data, except?)` — send `[event, data]` to every member of `name`, optionally skipping one connection (e.g. pass `ws` to exclude the sender). Returns the number of clients sent to.
+- `room.emit(name, event, data, except?)` — send `[event, data]` to every member of `name`, optionally skipping one connection (e.g. pass `ws` to exclude the sender). `except` may be any connection, not just the sender. Returns the number of clients sent to.
 - `room.size(name)` — number of connections currently in room `name`.
 
 `emit` is connection-agnostic, so a later callback (e.g. a timer) can multicast to a room after the triggering message has resolved.

--- a/server.js
+++ b/server.js
@@ -45,46 +45,27 @@ export default async (
 
   const endpoints = await serveEndpoints(eventDir, "");
 
-  const clientPool = {};
+  // Rooms and broadcast ride on Bun's native pub/sub: membership lives on the
+  // socket, so it clears itself on disconnect. Room topics are namespaced to
+  // keep a room named "broadcast" from colliding with the global topic.
+  const BROADCAST = "broadcast";
+  const topicOf = (name) => `room:${name}`;
 
-  const broadcast = (body, ws = undefined) =>
-    Object.values(clientPool).forEach(
-      (client) =>
-        ws !== client && client.send(JSON.stringify(["broadcast", body])),
-    );
+  // `except` publishes from that socket, which excludes exactly it — works for
+  // the sender, any other connection, and even one that already disconnected.
+  const publish = (topic, payload, except = undefined) =>
+    except ? except.publish(topic, payload) : server.publish(topic, payload);
 
-  // Rooms: targeted multicast to a named subset of connections. Membership is
-  // per-connection (a Set of ws), so it clears automatically on disconnect.
-  // Handlers receive a `room` API in their context; emit is ws-agnostic so a
-  // later callback (e.g. a timer) can multicast after the triggering message.
-  const rooms = {};
-
-  const joinRoom = (ws, name) => (rooms[name] ??= new Set()).add(ws);
-
-  const leaveRoom = (ws, name) => {
-    const members = rooms[name];
-    if (!members) return;
-    members.delete(ws);
-    if (!members.size) delete rooms[name];
-  };
-
-  const leaveAllRooms = (ws) => {
-    for (const name of Object.keys(rooms)) leaveRoom(ws, name);
-  };
+  const broadcast = (body, except = undefined) =>
+    publish(BROADCAST, JSON.stringify([BROADCAST, body]), except);
 
   const emitToRoom = (name, event, data, except = undefined) => {
-    const members = rooms[name];
-    if (!members) return 0;
-    let sent = 0;
-    for (const client of members)
-      if (client !== except) {
-        client.send(JSON.stringify([event, data]));
-        sent += 1;
-      }
-    return sent;
+    const topic = topicOf(name);
+    publish(topic, JSON.stringify([event, data]), except);
+    return server.subscriberCount(topic) - (except?.isSubscribed(topic) ? 1 : 0);
   };
 
-  serve({
+  const server = serve({
     port,
     fetch: (req, server) => {
       // A hack: use sec-websocket-protocol as the socket id (named `data` in Bun)
@@ -110,10 +91,10 @@ export default async (
         }
 
         const room = {
-          join: (name) => joinRoom(ws, name),
-          leave: (name) => leaveRoom(ws, name),
+          join: (name) => ws.subscribe(topicOf(name)),
+          leave: (name) => ws.unsubscribe(topicOf(name)),
           emit: emitToRoom,
-          size: (name) => rooms[name]?.size || 0,
+          size: (name) => server.subscriberCount(topicOf(name)),
         };
 
         const resolution = func(body || {}, { ws, room, ...services });
@@ -150,15 +131,11 @@ export default async (
         })();
       },
       open: (ws) => {
-        clientPool[ws.data] = ws;
+        ws.subscribe(BROADCAST);
 
         ws.sendEvent = (event, data) => ws.send(JSON.stringify([event, data]));
         ws.broadcast = (body, includeSelf = false) =>
-          broadcast(body, includeSelf || ws);
-      },
-      close: (ws, code, message) => {
-        delete clientPool[ws.data];
-        leaveAllRooms(ws);
+          broadcast(body, includeSelf ? undefined : ws);
       },
       drain: (ws) => {},
     },


### PR DESCRIPTION
`rooms` and `clientPool` were a hand-rolled re-implementation of pub/sub that Bun already ships natively. This replaces the machinery with `ws.subscribe` / `ws.publish` / `server.publish` / `server.subscriberCount` and keeps the public API byte-for-byte identical.

## What got deleted

- `clientPool` — the `Record<string, ws>` keyed by the client-supplied `sec-websocket-protocol` header
- `rooms`, `joinRoom`, `leaveRoom`, `leaveAllRooms`, `emitToRoom`'s manual iteration
- the entire `close` handler — Bun auto-unsubscribes a socket from every topic when it disconnects

`server.js` goes from 168 to 145 lines.

## API unchanged

Nothing consumers touch moved:

- handlers still receive `room.join(name)` / `room.leave(name)` / `room.emit(name, event, data, except?)` / `room.size(name)`
- sockets still get `ws.sendEvent(event, data)` and `ws.broadcast(body, includeSelf)`
- `ws.broadcast` is still an arrow closing over `ws`, so the destructured `({ ws: { broadcast } }) => broadcast(...)` form in `examples/` keeps working
- the wire format is unchanged: `[event, data]`, and broadcasts remain `["broadcast", body]`

## Semantic notes

**Topic namespacing.** Rooms map to `room:${name}`, the global fan-out to `broadcast`. Without the prefix a user room literally named `broadcast` would have merged with the global topic.

**`except` handling.** The signature allows an arbitrary socket, not just the sender. Publishing *from* a socket is sender-excluding by default in Bun (`publishToSelf` is off), so `except.publish(topic, payload)` excludes exactly that socket whichever one it is — no special-casing between "the caller" and "someone else". Verified that this holds even when `except` has already disconnected: the remaining subscribers still receive the message. The `except`-less path uses `server.publish`, which reaches everyone.

The only real-world use of `except` is `server/events/teamplay/start.js` in webdev-game-stack, which passes the calling `ws` to skip the sender that is already getting the async reply. That behavior is preserved exactly; the arbitrary-socket case is preserved too, rather than being narrowed to the sender.

**Counts.** `room.emit` still returns a recipient count, now derived as `subscriberCount(topic)` minus one when `except` is subscribed. `room.size` is `subscriberCount` directly.

**Serialization.** `JSON.stringify` now runs once per publish instead of once per recipient.

## Bug fixed as a side effect

`clientPool` was keyed by `sec-websocket-protocol`, which is `null` for any client that connects without a subprotocol. Every vanilla client therefore collapsed onto the same `null` key: connecting a second one evicted the first from the pool, and the first one's `close` deleted the shared entry, silently cutting the rest off from broadcasts.

This PR **supersedes #10 (`fix/broadcast-pool-identity`)**, which patched the key. There is no pool left to key.

## Verification

Throwaway Bun harness, 3+ clients against a live server, run against both this branch and `main`:

| | this branch | `main` |
|---|---|---|
| (a) `room.emit` reaches exactly the members, non-members excluded | pass | pass |
| (a) `except = sender` honored; counts 2 and 1 correct | pass | pass |
| (b) `room.size` correct for joined / unknown / post-`leave` rooms | pass | pass |
| (c) member disconnects → size drops with no manual cleanup | pass | pass |
| (d) `ws.broadcast(body)` reaches others but not self | pass | pass |
| (d) `ws.broadcast(body, true)` reaches all including self | pass | pass |
| (e) three no-subprotocol clients all receive broadcasts | pass | **fail** (1 of 3) |
| (e) closing one no-subprotocol client does not evict the others | pass | **fail** (0 of 2) |

The two `main` failures are the `clientPool` bug above. No version bump, no CHANGELOG entry.
