### PR TITLE
feat: correlate sendAsync replies with a request id

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,18 @@ ws.on('open', () => {
 - `payload` (any, default `undefined`)
 - `timeout in ms` (integer, default `3000`)
 
+Every `sendAsync` call gets its own request id and resolves only on the reply carrying that id. Concurrent calls to the same event therefore each receive their own result, and a server push (`ws.sendEvent` / `room.emit`) that happens to share the event name never resolves a pending request — it goes to `ws.on` subscribers, where it belongs. A reply that arrives after the timeout has already rejected is dropped.
+
+## Wire protocol
+
+Messages are JSON tuples.
+
+- Request: `[event, payload]`, or `[event, payload, id]` when the client wants a correlated reply (this is what `sendAsync` sends; `sendSync` sends the two-element form).
+- Reply: the server echoes the id it was given — `[event, result, id]`. A request without an id is answered with `[event, result]`, exactly as before.
+- Push: `[event, data]` — server-initiated messages never carry an id, so the client always routes them to `ws.on`.
+
+Ids are opaque strings; a client that never sends one keeps the original behavior, so old clients and new servers interoperate in both directions.
+
 ## Error handling
 
 When calling `ws.sendAsync('some-event')` there are two possible failures:

--- a/client.js
+++ b/client.js
@@ -1,5 +1,9 @@
 let ws, reconnector, eventTarget;
 
+// In-flight sendAsync requests, keyed by the id sent on the wire. Replies are
+// correlated by id, never by event name.
+const pending = new Map();
+
 const generateID = () =>
   `_${
     Number(String(Math.random()).slice(2)) +
@@ -20,19 +24,15 @@ const AsyncAwaitWebsocket = (url, options) => {
 
   ws.sendAsync = (event, data, timeout = 3000) =>
     new Promise((resolve, reject) => {
-      const trigger = ({ detail }) => {
-        clearTimeout(id);
-        eventTarget.removeEventListener(event, trigger);
-        detail?.error ? reject(detail) : resolve(detail);
-      };
+      const id = generateID();
 
-      const id = setTimeout(() => {
-        eventTarget.removeEventListener(event, trigger);
+      const timer = setTimeout(() => {
+        pending.delete(id);
         reject({ error: "WebSocket error (client): request timed out" });
       }, timeout);
 
-      ws.send(JSON.stringify([event, data]));
-      eventTarget.addEventListener(event, trigger);
+      pending.set(id, { resolve, reject, timer });
+      ws.send(JSON.stringify([event, data, id]));
     });
 
   ws.on = (event, callback) => {
@@ -59,8 +59,19 @@ const AsyncAwaitWebsocket = (url, options) => {
   );
 
   ws.addEventListener("message", ({ data }) => {
-    const [event, detail] = JSON.parse(data);
-    eventTarget.dispatchEvent(new CustomEvent(event, { detail }));
+    const [event, detail, id] = JSON.parse(data);
+    const request = id && pending.get(id);
+
+    if (request) {
+      clearTimeout(request.timer);
+      pending.delete(id);
+      detail?.error ? request.reject(detail) : request.resolve(detail);
+      return;
+    }
+
+    // Id-less frames are server pushes and go to ws.on subscribers; an id we no
+    // longer track is a reply that lost the race against its timeout.
+    if (!id) eventTarget.dispatchEvent(new CustomEvent(event, { detail }));
   });
 
   return ws;

--- a/server.js
+++ b/server.js
@@ -4,6 +4,11 @@ import { pathToFileURL } from "node:url";
 
 const { serve } = Bun;
 
+// Replies echo the request id when the client sent one, so concurrent requests
+// for the same event stay apart. Id-less requests get the plain tuple.
+const reply = (ws, event, data, id) =>
+  ws.send(JSON.stringify(id ? [event, data, id] : [event, data]));
+
 const serveEndpoints = async (root, path) => {
   const endpoints = fetchEndpoints(root, path);
   const results = await Promise.all(Object.values(endpoints));
@@ -99,13 +104,13 @@ export default async (
     },
     websocket: {
       message: (ws, msg) => {
-        const [event, body] = JSON.parse(msg.toString());
+        const [event, body, id] = JSON.parse(msg.toString());
         const func = endpoints?.[event];
 
         if (!func) {
           const error = `Unknown event: ${event}`;
           console.error(error, "— registered:", Object.keys(endpoints));
-          ws.send(JSON.stringify([event, { error }]));
+          reply(ws, event, { error }, id);
           return;
         }
 
@@ -133,7 +138,7 @@ export default async (
             error = err.toString();
           }
 
-          async && ws.send(JSON.stringify([event, error ? { error } : result]));
+          async && reply(ws, event, error ? { error } : result, id);
 
           typeof log === "function" &&
             log(


### PR DESCRIPTION
`sendAsync` correlated replies purely by **event name**: it registered a one-shot listener for `event` on the shared `EventTarget` and resolved on the first frame that arrived under that name. Two things fall out of that, both reproduced against `main`:

## The repro

**Cross-resolution.** Two concurrent `sendAsync('echo', …)` calls both resolve with whichever reply lands first. The second reply arrives to zero listeners (the first `trigger` already removed itself) and is silently dropped:

```
FAIL (a) concurrent same-event requests resolve with own payloads
     first={"tag":"second","delay":20} second={"tag":"second","delay":20}
```

Both promises got the *second* request's payload. The consumer `webdev-game-stack` has real susceptible sites — overlapping `teamplay/get` calls.

**Push hijacking.** A handler that pushes `ws.sendEvent('pushy', …)` before returning resolves the caller's pending `sendAsync('pushy')` with the push instead of the reply:

```
FAIL (b) push does not hijack the promise — resolved with {"push":true}
```

**Leaked late replies.** After a timeout rejects, the reply still arrives and is dispatched on the `EventTarget`, so unrelated `ws.on(event)` subscribers receive a stale response frame.

## The fix

The JSON-RPC lesson: put an id on the wire.

- **Client** — `sendAsync` generates a per-request id, sends `[event, data, id]`, and parks `{ resolve, reject, timer }` in a `pending` Map keyed by that id. A frame carrying an id settles exactly its own request and is never dispatched to the `EventTarget`; an id with no pending entry (a reply that lost the race against its timeout) is dropped. Id-less frames — server pushes — still go to `ws.on`. `eventTarget` stays exactly as it was for subscriptions.
- **Server** — destructures the optional third element and echoes it: `[event, result, id]`. A request without an id is answered with the plain `[event, result]`, byte-for-byte as before. Both reply sites go through one `reply(ws, event, data, id)` helper, including the unknown-event error, so a `sendAsync` for an unregistered event rejects instead of hanging until timeout.

**Id source: the existing `generateID()`**, not `crypto.randomUUID()`. It's already in the file (it generates the socket's subprotocol id), keeps the lib zero-dependency-and-zero-branch, and works everywhere the client runs — `crypto.randomUUID` is `undefined` outside a secure context, so a page served over plain HTTP from a LAN address would break on it.

## Wire compatibility

Ids are optional in both directions:

- Old client → new server: no id in, no id out, identical frames.
- New client → old server: the extra array element is ignored by `const [event, body] = JSON.parse(…)`; the reply comes back id-less. (`sendAsync` would then not resolve, so this direction wants both sides updated — but nothing crashes.)
- `sendSync` is untouched and still sends the two-element tuple, so its reply keeps flowing to `ws.on`.
- Pushes (`ws.sendEvent`, `room.emit`, `broadcast`) are unchanged and never carry an id.

`index.d.ts` needs no change — the public signature is the same.

## Verification

Throwaway Bun harness (a live server, an `aaw` client, plus a hand-rolled `WebSocket` speaking the old tuples), run against both this branch and `main`:

| | this branch | `main` |
|---|---|---|
| (a) concurrent same-event requests resolve with their own payloads | pass | **fail** |
| (b) same-name push does not hijack the promise | pass | **fail** |
| (b) that push still reaches `ws.on` | pass | pass |
| (c) id-less raw client gets an old-style 2-tuple reply | pass | pass |
| (c2) `sendSync` reply still dispatched to `ws.on` | pass | **fail** (also saw a leaked reply from an earlier request) |
| (d) timeout still rejects | pass | pass |
| (d) late reply dropped, not delivered anywhere | pass | **fail** |
| (e) handler error rejects its own request, sibling request unaffected | pass | pass |
| (f) unknown event rejects with the server error | pass | pass |

9/9 here, 5/9 on `main`.

## Merge note

The parallel PR `fix/reply-for-thenables` touches the same reply block in `server.js`. Merge these sequentially — the conflict is trivial (one branch changes what is sent, this one changes how it is addressed).

No version bump, no CHANGELOG entry.
