### PR TITLE
fix(crash): a throwing sync handler no longer kills the server

### DIFF
--- a/server.js
+++ b/server.js
@@ -155,24 +155,18 @@ export default async (
           size: (name) => rooms[name]?.size || 0,
         };
 
-        const resolution = func(body || {}, {
-          ws,
-          room,
-          ...services,
-          ...(authentication && authentication.context(ws)),
-        });
-
         (async () => {
-          try {
-            const res = await resolution;
-          } catch (_) {}
+          const async = func.constructor.name === "AsyncFunction";
 
-          let result,
-            error,
-            async = func.constructor.name === "AsyncFunction";
+          let result, error;
 
           try {
-            result = async ? await resolution : resolution;
+            result = await func(body || {}, {
+              ws,
+              room,
+              ...services,
+              ...(authentication && authentication.context(ws)),
+            });
           } catch (err) {
             error = err.message ?? String(err);
           }


### PR DESCRIPTION
**Severity: critical — remote process kill via ordinary handler code.**

The handler was invoked outside the try/catch, so a synchronous throw escaped Bun's `message` callback and terminated the process. The README documents sync handlers, and `if (!body.id) throw Error(...)` is the natural validation — so any client sending an incomplete body killed the server.

Moving the call inside the async block catches it the same way an async rejection already was.

Verified: standalone server survives a sync handler throw; normal handlers unaffected.

Conflicts with `fix/malformed-json-crash`, `fix/prototype-event-lookup`, `fix/empty-error-success`, `fix/service-name-collision`, `fix/live-session-revocation` (all touch server.js).