### PR TITLE
fix(crash): a malformed frame no longer kills the server

### DIFF
--- a/server.js
+++ b/server.js
@@ -129,7 +129,14 @@ export default async (
     },
     websocket: {
       message: (ws, msg) => {
-        const [event, body] = JSON.parse(msg.toString());
+        let event, body;
+
+        try {
+          [event, body] = JSON.parse(msg.toString());
+        } catch {
+          return;
+        }
+
         const func = endpoints?.[event];
 
         if (!func) {


### PR DESCRIPTION
**Severity: critical — one anonymous frame is a total outage.**

`JSON.parse` and the array destructuring ran outside any try, so a frame that was not valid JSON, or valid JSON that was not an `[event, body]` pair (`{}`, `null`, `5`), threw inside Bun's message callback and terminated the process. A frame we cannot read carries no event to answer, so it is dropped and the caller times out.

Verified: standalone server survives `not json`, `{"a":1}`, `null`; ping still works.

Touches server.js (see other server.js branches for conflicts).