### PR TITLE
fix(crash): a prototype-chain event name is an unknown event, not a crash

### DIFF
--- a/server.js
+++ b/server.js
@@ -130,7 +130,7 @@ export default async (
     websocket: {
       message: (ws, msg) => {
         const [event, body] = JSON.parse(msg.toString());
-        const func = endpoints?.[event];
+        const func = Object.hasOwn(endpoints, event) && endpoints[event];
 
         if (!func) {
           const error = `Unknown event: ${event}`;


### PR DESCRIPTION
**Severity: critical — anonymous DoS.**

`endpoints?.[event]` resolved inherited members, so `__proto__` returned Object.prototype (truthy → past the unknown-event check → past the guard), and `constructor`/`toString`/`valueOf` resolved to callables invoked with the full context. `Object.hasOwn` restricts the lookup to registered events.

Verified: all prototype keys return `Unknown event`; server stays alive; ping works.