### PR TITLE
fix(client): sends follow the live socket across a reconnect

### DIFF
--- a/client.js
+++ b/client.js
@@ -23,8 +23,9 @@ const AsyncAwaitWebsocket = (
 
   const ws = new WebSocket(url, generateID());
   ws.sid = ws.protocol;
+  state.socket = ws;
 
-  ws.sendSync = (event, data) => ws.send(JSON.stringify([event, data]));
+  ws.sendSync = (event, data) => state.socket.send(JSON.stringify([event, data]));
 
   ws.sendAsync = (event, data, timeout = 3000) =>
     new Promise((resolve, reject) => {
@@ -39,7 +40,7 @@ const AsyncAwaitWebsocket = (
         reject({ error: "WebSocket error (client): request timed out" });
       }, timeout);
 
-      ws.send(JSON.stringify([event, data]));
+      state.socket.send(JSON.stringify([event, data]));
       eventTarget.addEventListener(event, trigger);
     });
 


### PR DESCRIPTION
**Severity: critical — every consumer goes send-dead after its first network blip.**

Since the socket became a per-invocation `const`, `sendSync`/`sendAsync` closed over the first socket, so every call after an automatic reconnect went to the dead one and timed out while the connection looked healthy (receive kept working). The current socket now lives on `state` and both send through it — the caller's handle follows the reconnect the way it did when the binding was module-scoped, without bringing back the shared state that made two clients resolve each other's calls.

Verified: sends work after a server restart; two independent clients stay isolated.

Conflicts with the other client.js branches: `fix/slow-resume-logout`, `fix/open-dispatch-dead-socket`.