### PR TITLE
fix(client): a resume timeout no longer logs the user out

### DIFF
--- a/client.js
+++ b/client.js
@@ -36,7 +36,7 @@ const AsyncAwaitWebsocket = (
 
       const id = setTimeout(() => {
         eventTarget.removeEventListener(event, trigger);
-        reject({ error: "WebSocket error (client): request timed out" });
+        reject({ error: "WebSocket error (client): request timed out", timeout: true });
       }, timeout);
 
       ws.send(JSON.stringify([event, data]));
@@ -54,6 +54,8 @@ const AsyncAwaitWebsocket = (
 
     if (state.token)
       await ws.sendAsync("aaw/resume", { token: state.token }).catch((error) => {
+        if (error.timeout) return;
+
         state.token = undefined;
         eventTarget.dispatchEvent(new CustomEvent("unauthorized", { detail: error }));
       });


### PR DESCRIPTION
**Severity: high — a slow reconnect logs out the whole fleet.**

The automatic resume treated any rejection as proof the session was invalid, so a slow reply (cold store, thundering-herd reconnect after a restart) cleared the token and emitted `unauthorized` even though the session was fine and the server went on to bind it. A client timeout now carries a `timeout` flag, and resume keeps the token on it; only a server-sent error clears the session.

Verified: a slow-but-valid resume keeps the token and ends up authenticated; a genuine `Session expired` still fires `unauthorized`.

Conflicts with the other client.js branches.