### PR TITLE
fix(client): do not dispatch open for a socket that already closed

### DIFF
--- a/client.js
+++ b/client.js
@@ -58,7 +58,8 @@ const AsyncAwaitWebsocket = (
         eventTarget.dispatchEvent(new CustomEvent("unauthorized", { detail: error }));
       });
 
-    eventTarget.dispatchEvent(new CustomEvent("open", { detail }));
+    if (ws.readyState === WebSocket.OPEN)
+      eventTarget.dispatchEvent(new CustomEvent("open", { detail }));
   });
 
   ws.addEventListener("close", (detail) => {


### PR DESCRIPTION
**Severity: medium — duplicate `open`, one for a dead socket.**

`sendAsync` listeners are keyed by event name on the shared EventTarget, so a late `aaw/resume` reply could resolve the pending resume of a socket that had already closed and reconnected, making its open handler fire a second `open` for a dead socket. The handler now dispatches `open` only while its socket is still open.

Verified: base dispatches `open` twice (once for the closed socket); this branch dispatches once.

Conflicts with the other client.js branches.