### PR TITLE
fix: an error with an empty message still rejects the caller

### DIFF
--- a/server.js
+++ b/server.js
@@ -174,7 +174,7 @@ export default async (
           try {
             result = async ? await resolution : resolution;
           } catch (err) {
-            error = err.message ?? String(err);
+            error = err.message || String(err);
           }
 
           async && ws.send(JSON.stringify([event, error ? { error } : result]));


### PR DESCRIPTION
**Severity: high — a failed handler is reported as success.**

`??` only falls back on null/undefined, so a thrown `Error()` with an empty message left `error` as `""` — falsy at the send site, which then shipped the `undefined` result as a successful `null`. `||` falls back on the empty string too, so a handler that threw always answers with an error. A failed authorization check that threw an empty custom Error was silently succeeding.

Verified: `throw Error()`, an empty custom subclass, and `throw Error('msg')` all reject; the message is preserved when present.

Touches server.js.