### PR TITLE
fix(auth): logout, expiry and reset revoke live connections

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -90,10 +90,14 @@ export default (config) => {
       return pathname.endsWith("/callback") ? link(provider, request) : provider.start(request);
     },
 
-    guard: (event, ws) => {
+    guard: async (event, ws) => {
       if (!guarded(event)) return;
-      if (!ws.identity) return "Not authenticated";
-      if (!permitted(ws.identity.allowed, event)) return `Not allowed: ${event}`;
+
+      const identity = ws.token && (await store.readSession(ws.token));
+      if (!identity) return "Not authenticated";
+
+      ws.identity = identity;
+      if (!permitted(identity.allowed, event)) return `Not allowed: ${event}`;
     },
 
     context: (ws) => ({

--- a/auth/sqlite.js
+++ b/auth/sqlite.js
@@ -60,6 +60,7 @@ export default (filename = "aaw-auth.sqlite") => {
     "SELECT users.* FROM users JOIN sessions ON sessions.user_id = users.id WHERE sessions.token = $token AND sessions.expires > $now",
   );
   const deleteSession = db.query("DELETE FROM sessions WHERE token = $token");
+  const deleteSessionsFor = db.query("DELETE FROM sessions WHERE user_id = $user_id");
   const expireSessions = db.query("DELETE FROM sessions WHERE expires <= $now");
   const insertReset = db.query(
     "INSERT INTO resets (token, user_id, expires) VALUES ($token, $user_id, $expires)",
@@ -133,6 +134,7 @@ export default (filename = "aaw-auth.sqlite") => {
       if (!row) return null;
 
       deleteReset.run({ $token: token });
+      deleteSessionsFor.run({ $user_id: row.user_id });
       updatePassword.run({
         $id: row.user_id,
         $password: await Bun.password.hash(password),

--- a/server.js
+++ b/server.js
@@ -128,7 +128,7 @@ export default async (
       );
     },
     websocket: {
-      message: (ws, msg) => {
+      message: async (ws, msg) => {
         const [event, body] = JSON.parse(msg.toString());
         const func = endpoints?.[event];
 
@@ -140,7 +140,7 @@ export default async (
         }
 
         const denied = authentication
-          ? authentication.guard(event, ws)
+          ? await authentication.guard(event, ws)
           : guarded(event) && `Authentication is not enabled — ${event} is unreachable`;
 
         if (denied) {


### PR DESCRIPTION
**Severity: high — a compromised session cannot be revoked.**

`guard()` trusted the identity cached on the socket at bind time and never re-checked, so a deleted session, an expired TTL, or a password reset only affected the connection that triggered it — any other socket holding the token kept full access for its lifetime. The guard now re-resolves the session from the store on each protected call, and a password reset clears the user's sessions.

**Trade-off (deliberate, please weigh):** a store read per `auth/` call, where identity was previously read once at bind. Public events are untouched. For the built-in store it is one indexed lookup; a network-backed custom store pays a round trip per protected call — the cost of making revocation real.

Verified: a second socket sharing a token is denied after logout; a live socket is denied after TTL expiry; a password reset revokes the attacker's live session while the victim keeps a fresh one.

Touches server.js, auth/index.js, auth/sqlite.js — conflicts with the other auth branches.