### PR TITLE
fix(auth): a failed resume clears the socket's identity

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -47,10 +47,8 @@ export default (config) => {
   const restore = async (ws, token) => {
     const user = await store.readSession(token);
 
-    if (user) {
-      ws.identity = user;
-      ws.token = token;
-    }
+    ws.identity = user || undefined;
+    ws.token = user ? token : undefined;
 
     return user;
   };


### PR DESCRIPTION
**Severity: high — a rejected token leaves the socket authenticated as the previous user.**

`restore()` assigned identity only on success, so resuming with an expired or revoked token left whatever identity the socket already held while telling the caller the session was gone. It now clears identity and token when the session does not resolve.

Verified: after a failed resume the socket is `Not authenticated` instead of retaining the old identity.

Touches auth/index.js.