### PR TITLE
fix(auth): an auth/ folder protects its events at any depth

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -8,7 +8,7 @@ const PROTECTED = "auth/";
 
 export const reserved = (event) => event.startsWith(RESERVED);
 
-export const guarded = (event) => event.startsWith(PROTECTED);
+export const guarded = (event) => event.startsWith(PROTECTED) || event.includes(`/${PROTECTED}`);
 
 const permitted = (allowed, event) =>
   !allowed ||


### PR DESCRIPTION
**Severity: high — a nested auth/ folder is silently public.**

`guarded()` only matched a top-level `auth/`, so `events/teamplay/auth/secret.js` registered as a public event despite sitting in an `auth/` folder. It now also matches an `auth/` segment mid-path, while a lookalike like `myauth/` stays open.

Verified: `teamplay/auth/secret` and top-level `auth/*` both guarded; `myauth/public` stays reachable.

Touches auth/index.js.