### PR TITLE
fix(auth): a service colliding with an auth context key throws at boot

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,6 +57,12 @@ export default async (
   const authentication = auth && createAuth(auth);
 
   if (authentication) {
+    const reserved = authentication.context({});
+    const collision = Object.keys(services).find((key) => Object.hasOwn(reserved, key));
+
+    if (collision)
+      throw new Error(`Service "${collision}" collides with a reserved authentication key`);
+
     const builtIn = await serveEndpoints(`${import.meta.dir}/events`, "");
 
     Object.entries(handlers(builtIn))


### PR DESCRIPTION
**Severity: high — turning auth on silently breaks a service named `auth`.**

The auth context (`identity`, `authenticate`, `auth`) is spread after the consumer's services, so a service named `auth` was silently replaced the moment auth was turned on, breaking every handler that used it. Boot now refuses a services key that collides, the same discipline already applied to reserved event names.

Verified: `{ auth }` and `{ identity }` throw at boot with a clear message; `{ mongo }` boots.

Touches server.js.