### PR TITLE
fix(auth): unsupported built-ins answer a plain error, no capability gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project are documented here. This project adheres to
   - **Server-minted sessions** bound to the connection. Identity is established once, not re-proven in every message body, and handlers receive it as `identity`.
   - **Built-in SQLite store** (`bun:sqlite`, no new dependency) holding users, linked providers, sessions and password resets. Passwords are hashed with `Bun.password` (Argon2id).
   - **`aaw/*` events** — `register`, `login`, `resume`, `logout`, `password/request-reset`, `password/set-new`. They live in the package's own `events/aaw/` folder as ordinary event files, named by their path exactly like yours, and registered alongside yours when auth is on. They sit outside `auth/` because a caller has to be able to log in before it holds anything to log in with. Reserved while auth is on; an event file that collides stops the server at boot instead of being silently shadowed.
-  - Each built-in event declares its provider (`export const provider = "sqlite"`), so naming a different provider leaves it unregistered rather than failing at call time.
+  - A built-in that needs a store method the configured store does not implement answers `Auth is not set up via aaw`, rather than exposing the missing internal call.
   - **Reset tokens** are `crypto.randomUUID()` with an expiry enforced where the password actually changes. `request-reset` answers identically for known and unknown addresses, so it cannot enumerate accounts.
   - **`allowed` globs** on an identity, matched against the event path (`*`, `auth/teamplay/*`, an exact path).
   - **Bring your own store** — pass `store` and aaw never opens a database. `authenticate(user)` in the handler context binds a session for credentials aaw knows nothing about.

--- a/auth/index.js
+++ b/auth/index.js
@@ -22,17 +22,21 @@ const permitted = (allowed, event) =>
 const named = (provider) => (typeof provider === "string" ? { name: provider } : provider);
 
 export default (config) => {
+  const options = config === true ? {} : config;
   const {
     providers = ["sqlite"],
     database,
-    store = sqlite(database),
     session: { ttl: sessionTtl = 30 * DAY } = {},
     reset: { ttl: resetTtl = 20 * MINUTE } = {},
     onPasswordReset,
-  } = config === true ? {} : config;
+  } = options;
+
+  const store = new Proxy(options.store ?? sqlite(database), {
+    get: (target, method) =>
+      target[method] ?? (() => { throw Error("Auth is not set up via aaw"); }),
+  });
 
   const enabled = providers.map(named);
-  const names = enabled.map(({ name }) => name);
   const social = enabled.filter(({ name }) => name !== "sqlite");
 
   const start = async (ws, user) => {
@@ -78,8 +82,6 @@ export default (config) => {
 
   return {
     store,
-
-    supports: ({ provider }) => !provider || names.includes(provider),
 
     http: (request) => {
       const { pathname } = new URL(request.url);

--- a/events/aaw/login.js
+++ b/events/aaw/login.js
@@ -1,5 +1,3 @@
-export const provider = "sqlite";
-
 export default async ({ email, password }, { authenticate, auth: { store } }) => {
   const user = await store.verify(email, password);
 

--- a/events/aaw/password/request-reset.js
+++ b/events/aaw/password/request-reset.js
@@ -1,5 +1,3 @@
-export const provider = "sqlite";
-
 export default async ({ email }, { auth: { store, reset, onPasswordReset } }) => {
   if (!onPasswordReset)
     throw Error("Password reset is not configured (no onPasswordReset handler)");

--- a/events/aaw/password/set-new.js
+++ b/events/aaw/password/set-new.js
@@ -1,5 +1,3 @@
-export const provider = "sqlite";
-
 export default async ({ token, password }, { authenticate, auth: { store } }) => {
   if (!password) throw Error("A new password is required");
 

--- a/events/aaw/register.js
+++ b/events/aaw/register.js
@@ -1,5 +1,3 @@
-export const provider = "sqlite";
-
 export default async ({ email, password }, { authenticate, auth: { store } }) => {
   if (!email || !password) throw Error("Email and password are required");
   if (await store.findUser(email)) throw Error("Email already registered");

--- a/server.js
+++ b/server.js
@@ -59,9 +59,7 @@ export default async (
   if (authentication) {
     const builtIn = await serveEndpoints(`${import.meta.dir}/events`, "");
 
-    Object.entries(handlers(builtIn))
-      .filter(([event]) => authentication.supports(builtIn[event]))
-      .forEach(([event, fn]) => (endpoints[event] = fn));
+    Object.entries(handlers(builtIn)).forEach(([event, fn]) => (endpoints[event] = fn));
   }
 
   const unreachable = authentication ? [] : Object.keys(endpoints).filter(guarded);


### PR DESCRIPTION
**Reworked per review — dumbed down.**

The original version declared `export const requires = [...]` on each built-in and gated registration on store capability. That meant naming methods and maintaining a scoring check — over-engineered for the benefit.

This version drops all of that:

- The built-ins carry **no metadata** (no `provider`, no `requires`).
- `supports()` and the `names` list are **removed** — built-ins are always registered when auth is on.
- The store is wrapped once so any method it does not implement answers a single plain error: **`Auth is not set up via aaw`**.

```js
const unsupported = () => { throw Error("Auth is not set up via aaw"); };
const store = new Proxy(options.store ?? sqlite(database), {
  get: (target, method) => target[method] ?? unsupported,
});
```

So a custom store that only implements `verify`/`createSession`/`readSession`/`endSession` gets working `aaw/login`/`logout`/`resume`, and `aaw/register` / `aaw/password/*` answer `Auth is not set up via aaw` instead of leaking `store.createUser is not a function`.

Net effect on the diff: **deletes** the gating machinery rather than adding to it. The lazy default is preserved — passing `store` still means no database file is opened.

Verified:
- Custom store: login/logout/resume work; register/set-new answer `Auth is not set up via aaw`.
- Default sqlite store: all six built-ins still work (register, reset, …).

Touches auth/index.js, server.js, the four `events/aaw/*` that had a `provider` line, CHANGELOG.md.