### PR TITLE
docs(auth): rooms carry no authentication; gate the join

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,17 @@ export default (body, { ws, room }) => {
 
 `emit` is connection-agnostic, so a later callback (e.g. a timer) can multicast to a room after the triggering message has resolved.
 
+### Rooms carry no authentication
+
+A socket receives a room's messages because a handler called `room.join` for it — nothing more. The guard only sees inbound calls, so it never inspects who is in a room. If a room carries data only some connections should see, gate the join: put the event that calls `room.join` under `auth/`, or guard it on `identity`. Otherwise a public event that joins a socket to a protected room lets that socket receive everything emitted to it, even though it could never write to it.
+
+```js
+// events/auth/subscribe.js — only a session can join, so only a session receives
+export default (body, { room }) => {
+  room.join(`teamplay:${body.id}`);
+};
+```
+
 ## Your client
 
 `npm install async-await-websockets`


### PR DESCRIPTION
**Severity: high (as documented example) — following the docs leaks protected data.**

The multicast primitive has no notion of a protected room — a socket receives a room's messages purely because a handler joined it, and the guard only sees inbound calls. A public event that joins a socket to a room protected handlers emit into leaks that data to connections that can never write to it. This documents the rule and shows the join placed under `auth/` so only a session can subscribe.

Docs-only (README.md). The multicast primitive is correct as a low-level tool; the fix is steering usage, since the library already provides `identity` and the `auth/` guard to gate membership.