### PR TITLE
fix: a refusal carries a message

### DIFF
--- a/client.js
+++ b/client.js
@@ -7,6 +7,8 @@ const generateID = () =>
     Math.round(performance.now()).toString(36)
   }`;
 
+const refusal = (detail) => Object.assign(new Error(detail.error), detail);
+
 const AsyncAwaitWebsocket = (url, options) => {
   // Create once; reuse across internal reconnects so listeners registered via
   // ws.on survive.
@@ -23,12 +25,12 @@ const AsyncAwaitWebsocket = (url, options) => {
       const trigger = ({ detail }) => {
         clearTimeout(id);
         eventTarget.removeEventListener(event, trigger);
-        detail?.error ? reject(detail) : resolve(detail);
+        detail?.error ? reject(refusal(detail)) : resolve(detail);
       };
 
       const id = setTimeout(() => {
         eventTarget.removeEventListener(event, trigger);
-        reject({ error: "WebSocket error (client): request timed out" });
+        reject(refusal({ error: "WebSocket error (client): request timed out" }));
       }, timeout);
 
       ws.send(JSON.stringify([event, data]));


### PR DESCRIPTION
`sendAsync` rejects with a bare object in both of its failure paths — the server's `detail`, and an object literal on timeout. Neither is an `Error`.

A rejection that reaches a browser console or a log file therefore prints as:

```
Uncaught (in promise) #<Object>
```

No message, no stack, nothing to act on. I spent a while chasing exactly that line in an Electron renderer log before finding it meant `{error: "Not authenticated"}`.

### The change

```js
const refusal = (detail) => Object.assign(new Error(detail.error), detail);
```

Applied at both reject sites. Same line now reads:

```
Uncaught (in promise) Error: Not authenticated
```

### Non-breaking

`Object.assign` onto a real `Error` keeps every field the server sent, so anything reading `refusal.error` is unaffected:

| | before | after |
|---|---|---|
| `instanceof Error` | false | **true** |
| `.message` | — | `Not authenticated` |
| `.error` | `Not authenticated` | `Not authenticated` |
| extra server fields (`.code`) | kept | kept |
| `.stack` | — | **present** |

`index.d.ts` types `sendAsync` as `=> any` and says nothing about the rejection, so typings need no change.

### One note on the repo

I wrote this against `main`, but `main` is at 3.1.0 while npm's latest is **3.2.1** (published 2026-08-20). The published client is the `state`-object form — `feat/optional-authentication` and `test/coverage` both carry it byte-identical, but nothing on `main` does, and there are no tags.

The bug is present in both forms, at the same two reject sites, so this applies either way — but it will want reapplying wherever 3.2.1 actually lives before the next publish.